### PR TITLE
fix: display login when stored role is invalid

### DIFF
--- a/helpdesk-frontend/src/App.js
+++ b/helpdesk-frontend/src/App.js
@@ -10,6 +10,7 @@ function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || null);
   const [rol, setRol] = useState(localStorage.getItem('rol') || null);
   const [showRegister, setShowRegister] = useState(false);
+  const validRoles = ['Solicitante', 'Tecnico', 'Administrador'];
 
   const handleLogin = (token, rol) => {
     setToken(token);
@@ -24,7 +25,7 @@ function App() {
     localStorage.clear();
   };
 
-  if (!token) {
+  if (!token || !validRoles.includes(rol)) {
     return (
       <div>
         {showRegister ? (


### PR DESCRIPTION
## Summary
- ensure login is shown if stored role is missing or invalid

## Testing
- `cd helpdesk-frontend && npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68994182e5188329b9721a3851e34215