### PR TITLE
Fix login by renaming password field without accent

### DIFF
--- a/HelpDeskAPI/Controllers/AuthController.cs
+++ b/HelpDeskAPI/Controllers/AuthController.cs
@@ -20,7 +20,7 @@ namespace HelpDeskAPI.Controllers
         public async Task<IActionResult> Login([FromBody] LoginRequest request)
         {
             var user = await _context.Users
-                .FirstOrDefaultAsync(u => u.Correo == request.Correo && u.Contraseña == request.Contraseña);
+                .FirstOrDefaultAsync(u => u.Correo == request.Correo && u.Contrasena == request.Contrasena);
 
             if (user == null)
             {

--- a/HelpDeskAPI/Controllers/UsersController.cs
+++ b/HelpDeskAPI/Controllers/UsersController.cs
@@ -48,9 +48,9 @@ namespace HelpDeskAPI.Controllers
         public IActionResult Login([FromBody] LoginRequest loginRequest)
         {
             var correo = loginRequest.Correo;
-            var contraseña = loginRequest.Contraseña;
+            var contrasena = loginRequest.Contrasena;
 
-            var user = _context.Users.FirstOrDefault(u => u.Correo == correo && u.Contraseña == contraseña);
+            var user = _context.Users.FirstOrDefault(u => u.Correo == correo && u.Contrasena == contrasena);
             if (user == null)
             {
                 return Unauthorized();
@@ -77,7 +77,7 @@ namespace HelpDeskAPI.Controllers
 
             user.Nombre = updatedUser.Nombre;
             user.Correo = updatedUser.Correo;
-            user.Contraseña = updatedUser.Contraseña;
+            user.Contrasena = updatedUser.Contrasena;
             user.Rol = updatedUser.Rol;
 
             await _context.SaveChangesAsync();

--- a/HelpDeskAPI/Models/LoginRequest.cs
+++ b/HelpDeskAPI/Models/LoginRequest.cs
@@ -3,6 +3,6 @@ namespace HelpDeskAPI.Models
     public class LoginRequest
     {
         public string Correo { get; set; } = string.Empty;
-        public string Contraseña { get; set; } = string.Empty;
+        public string Contrasena { get; set; } = string.Empty;
     }
 }

--- a/HelpDeskAPI/Models/LoginRequestUser.cs
+++ b/HelpDeskAPI/Models/LoginRequestUser.cs
@@ -3,6 +3,6 @@ namespace HelpDeskAPI.Models
     public class LoginRequestUser
     {
         public string Correo { get; set; }
-        public string Contraseña { get; set; }
+        public string Contrasena { get; set; }
     }
 }

--- a/HelpDeskAPI/Models/User.cs
+++ b/HelpDeskAPI/Models/User.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace HelpDeskAPI.Models
 {
@@ -13,7 +14,8 @@ namespace HelpDeskAPI.Models
         public string Correo { get; set; } = string.Empty;
 
         [Required]
-        public string Contraseña { get; set; } = string.Empty;
+        [Column("Contraseña")]
+        public string Contrasena { get; set; } = string.Empty;
 
         [Required]
         public string Rol { get; set; } = string.Empty; // ejemplo: "Usuario", "Técnico", "Admin"

--- a/helpdesk-frontend/src/components/Login.jsx
+++ b/helpdesk-frontend/src/components/Login.jsx
@@ -16,7 +16,7 @@ export default function Login({ onLogin, onShowRegister }) {
       const response = await fetch('http://localhost:5131/api/users/login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ correo, contraseña: contrasena })
+        body: JSON.stringify({ correo, contrasena })
       });
 
       if (!response.ok) {

--- a/helpdesk-frontend/src/components/Register.jsx
+++ b/helpdesk-frontend/src/components/Register.jsx
@@ -17,7 +17,7 @@ export default function Register({ onBack }) {
       const response = await fetch('http://localhost:5131/api/users', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nombre, correo, contraseña: contrasena, rol: 'Usuario' })
+        body: JSON.stringify({ nombre, correo, contrasena, rol: 'Usuario' })
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Rename password property to `Contrasena` and map to DB column to avoid Unicode parameter issues
- Update login endpoints and frontend components to use `contrasena`

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `CI=true npm test -- --watch=false`


------
https://chatgpt.com/codex/tasks/task_e_6899b971c208832985436fcc2b11e66a