### PR TITLE
Default admin role when registering

### DIFF
--- a/HelpDeskAPI/Controllers/AuthController.cs
+++ b/HelpDeskAPI/Controllers/AuthController.cs
@@ -43,6 +43,11 @@ namespace HelpDeskAPI.Controllers
                 return BadRequest(ModelState);
             }
 
+            if (string.IsNullOrWhiteSpace(user.Rol))
+            {
+                user.Rol = "Administrador";
+            }
+
             _context.Users.Add(user);
             await _context.SaveChangesAsync();
 

--- a/HelpDeskAPI/Controllers/UsersController.cs
+++ b/HelpDeskAPI/Controllers/UsersController.cs
@@ -20,6 +20,11 @@ namespace HelpDeskAPI.Controllers
         [HttpPost]
         public async Task<IActionResult> CreateUser([FromBody] User user)
         {
+            if (string.IsNullOrWhiteSpace(user.Rol))
+            {
+                user.Rol = "Administrador";
+            }
+
             _context.Users.Add(user);
             await _context.SaveChangesAsync();
             return CreatedAtAction(nameof(GetUser), new { id = user.Id }, user);

--- a/HelpDeskAPI/Models/User.cs
+++ b/HelpDeskAPI/Models/User.cs
@@ -18,7 +18,7 @@ namespace HelpDeskAPI.Models
         public string Contrasena { get; set; } = string.Empty;
 
         [Required]
-        public string Rol { get; set; } = string.Empty; // ejemplo: "Usuario", "Técnico", "Admin"
+        public string Rol { get; set; } = string.Empty; // Roles: "Administrador", "Tecnico", "Solicitante"
 
         public ICollection<Ticket> TicketsCreados { get; set; } = new List<Ticket>();
 


### PR DESCRIPTION
## Summary
- default to Administrador role when creating users via UsersController and AuthController
- document available roles in User model

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*

------
https://chatgpt.com/codex/tasks/task_e_6899cb75b1a8832980cbd67d0b03599a