### PR TITLE
Default new users to Solicitante role

### DIFF
--- a/HelpDeskAPI/Controllers/AuthController.cs
+++ b/HelpDeskAPI/Controllers/AuthController.cs
@@ -45,7 +45,7 @@ namespace HelpDeskAPI.Controllers
 
             if (string.IsNullOrWhiteSpace(user.Rol))
             {
-                user.Rol = "Administrador";
+                user.Rol = "Solicitante";
             }
 
             _context.Users.Add(user);

--- a/HelpDeskAPI/Controllers/UsersController.cs
+++ b/HelpDeskAPI/Controllers/UsersController.cs
@@ -22,7 +22,7 @@ namespace HelpDeskAPI.Controllers
         {
             if (string.IsNullOrWhiteSpace(user.Rol))
             {
-                user.Rol = "Administrador";
+                user.Rol = "Solicitante";
             }
 
             _context.Users.Add(user);

--- a/helpdesk-frontend/src/components/Login.jsx
+++ b/helpdesk-frontend/src/components/Login.jsx
@@ -25,7 +25,7 @@ export default function Login({ onLogin, onShowRegister }) {
       }
 
       const data = await response.json();
-      onLogin(data.token, data.role || 'Usuario');
+      onLogin(data.token, data.role || 'Solicitante');
     } catch (err) {
       setError('Error de conexión');
     }

--- a/helpdesk-frontend/src/components/Register.jsx
+++ b/helpdesk-frontend/src/components/Register.jsx
@@ -17,7 +17,7 @@ export default function Register({ onBack }) {
       const response = await fetch('http://localhost:5131/api/users', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ nombre, correo, contrasena, rol: 'Usuario' })
+        body: JSON.stringify({ nombre, correo, contrasena, rol: 'Solicitante' })
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- ensure login and registration use `Solicitante` role
- default backend to `Solicitante` when role is missing

## Testing
- `dotnet build` *(fails: command not found)*
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6899dd2fc400832982f4d4edd57b89e7