### PR TITLE
Enable dashboard actions and ticket forms

### DIFF
--- a/helpdesk-frontend/src/App.js
+++ b/helpdesk-frontend/src/App.js
@@ -45,7 +45,7 @@ function App() {
   if (rol === 'Solicitante') {
     return (
       <>
-        <UserDashboard onLogout={handleLogout} />
+        <UserDashboard onLogout={handleLogout} token={token} role={rol} />
         <ChatBotWidget />
       </>
     );
@@ -54,7 +54,7 @@ function App() {
   if (rol === 'Tecnico') {
     return (
       <>
-        <TechnicianDashboard onLogout={handleLogout} />
+        <TechnicianDashboard onLogout={handleLogout} token={token} role={rol} />
         <ChatBotWidget />
       </>
     );
@@ -63,7 +63,7 @@ function App() {
   if (rol === 'Administrador') {
     return (
       <>
-        <AdminDashboard onLogout={handleLogout} />
+        <AdminDashboard onLogout={handleLogout} token={token} role={rol} />
         <ChatBotWidget />
       </>
     );

--- a/helpdesk-frontend/src/components/AdminDashboard.jsx
+++ b/helpdesk-frontend/src/components/AdminDashboard.jsx
@@ -14,7 +14,7 @@ import {
 } from 'react-icons/fi';
 import TicketList from './TicketList';
 
-export default function AdminDashboard({ onLogout }) {
+export default function AdminDashboard({ onLogout, token, role }) {
   const [notifications] = useState([
     { id: 1, text: 'Nuevo ticket asignado', time: '10 min ago', read: false },
     { id: 2, text: 'Actualización del sistema disponible', time: '1 hora ago', read: true },
@@ -203,7 +203,7 @@ export default function AdminDashboard({ onLogout }) {
               </div>
               <h3>Configurar Sistema</h3>
               <p>Administrar roles y categorías del sistema.</p>
-              <button className="card-button">Ir a Configuración</button>
+              <button className="card-button" onClick={() => setActiveMenu('settings')}>Ir a Configuración</button>
             </div>
 
             <div className="admin-card reports-card">
@@ -212,7 +212,7 @@ export default function AdminDashboard({ onLogout }) {
               </div>
               <h3>Ver Reportes</h3>
               <p>Visualizar estadísticas de tickets y rendimiento.</p>
-              <button className="card-button">Ver Reportes</button>
+              <button className="card-button" onClick={() => setActiveMenu('reports')}>Ver Reportes</button>
             </div>
 
             <div className="admin-card tickets-card">
@@ -221,7 +221,7 @@ export default function AdminDashboard({ onLogout }) {
               </div>
               <h3>Asignar Tickets</h3>
               <p>Asignar solicitudes a técnicos disponibles.</p>
-              <button className="card-button">Asignar Tickets</button>
+              <button className="card-button" onClick={() => setActiveMenu('tickets')}>Asignar Tickets</button>
             </div>
 
             <div className="admin-card users-card">
@@ -230,7 +230,7 @@ export default function AdminDashboard({ onLogout }) {
               </div>
               <h3>Gestionar Usuarios</h3>
               <p>Agregar, editar y eliminar cuentas de usuarios.</p>
-              <button className="card-button">Gestionar Usuarios</button>
+              <button className="card-button" onClick={() => setActiveMenu('users')}>Gestionar Usuarios</button>
             </div>
           </div>
           
@@ -266,7 +266,16 @@ export default function AdminDashboard({ onLogout }) {
             </div>
           </div>
           {activeMenu === 'tickets' && (
-            <TicketList currentUserId={3} />
+            <TicketList token={token} role={role} />
+          )}
+          {activeMenu === 'users' && (
+            <div className="placeholder">Gestión de usuarios en construcción</div>
+          )}
+          {activeMenu === 'settings' && (
+            <div className="placeholder">Configuración del sistema</div>
+          )}
+          {activeMenu === 'reports' && (
+            <div className="placeholder">Reportes del sistema</div>
           )}
         </main>
       </div>

--- a/helpdesk-frontend/src/components/TechnicianDashboard.jsx
+++ b/helpdesk-frontend/src/components/TechnicianDashboard.jsx
@@ -17,8 +17,9 @@ import {
   FiFileText
 } from 'react-icons/fi';
 import TicketList from './TicketList';
+import TicketForm from './TicketForm';
 
-export default function TechnicianDashboard({ onLogout }) {
+export default function TechnicianDashboard({ onLogout, token, role }) {
   const [notifications] = useState([
     { id: 1, text: 'Nuevo ticket asignado #TKT-00789', time: '10 min ago', read: false },
     { id: 2, text: 'Ticket #TKT-00425 requiere atención', time: '1 hora ago', read: true },
@@ -221,7 +222,7 @@ export default function TechnicianDashboard({ onLogout }) {
               </div>
               <h3>Ver Tickets Asignados</h3>
               <p>Revisa los tickets que te han sido asignados para atención.</p>
-              <button className="card-button">Ver Tickets</button>
+              <button className="card-button" onClick={() => setActiveMenu('tickets')}>Ver Tickets</button>
             </div>
 
             <div className="tech-card update-card">
@@ -230,7 +231,7 @@ export default function TechnicianDashboard({ onLogout }) {
               </div>
               <h3>Actualizar Estados</h3>
               <p>Marca los tickets como en progreso o resueltos.</p>
-              <button className="card-button">Actualizar</button>
+              <button className="card-button" onClick={() => setActiveMenu('tickets')}>Actualizar</button>
             </div>
 
             <div className="tech-card new-card">
@@ -239,7 +240,7 @@ export default function TechnicianDashboard({ onLogout }) {
               </div>
               <h3>Crear Reporte</h3>
               <p>Genera un nuevo reporte de incidencia o solicitud.</p>
-              <button className="card-button">Nuevo Reporte</button>
+              <button className="card-button" onClick={() => setActiveMenu('new')}>Nuevo Reporte</button>
             </div>
           </div>
           
@@ -280,8 +281,11 @@ export default function TechnicianDashboard({ onLogout }) {
               </div>
             ))}
           </div>
-          {['tickets', 'new'].includes(activeMenu) && (
-            <TicketList filter={{ tecnicoId: 2 }} currentUserId={2} />
+          {activeMenu === 'tickets' && (
+            <TicketList token={token} role={role} />
+          )}
+          {activeMenu === 'new' && (
+            <TicketForm token={token} />
           )}
         </main>
       </div>

--- a/helpdesk-frontend/src/components/UserDashboard.jsx
+++ b/helpdesk-frontend/src/components/UserDashboard.jsx
@@ -18,8 +18,9 @@ import {
   FiHelpCircle
 } from 'react-icons/fi';
 import TicketList from './TicketList';
+import TicketForm from './TicketForm';
 
-export default function UserDashboard({ onLogout }) {
+export default function UserDashboard({ onLogout, token, role }) {
   const [notifications] = useState([
     { id: 1, text: 'Tu ticket #TKT-00789 ha sido asignado', time: '10 min ago', read: false },
     { id: 2, text: 'Respuesta a tu ticket #TKT-00785', time: '1 hora ago', read: true },
@@ -222,7 +223,7 @@ export default function UserDashboard({ onLogout }) {
               </div>
               <h3>Crear Nuevo Ticket</h3>
               <p>Reporta cualquier problema técnico que tengas con el sistema.</p>
-              <button className="card-button">Nuevo Ticket</button>
+              <button className="card-button" onClick={() => setActiveMenu('new-ticket')}>Nuevo Ticket</button>
             </div>
 
             <div className="user-card check-status-card">
@@ -231,7 +232,7 @@ export default function UserDashboard({ onLogout }) {
               </div>
               <h3>Consultar Estado</h3>
               <p>Revisa el estado actual de tus tickets reportados.</p>
-              <button className="card-button">Ver Tickets</button>
+              <button className="card-button" onClick={() => setActiveMenu('my-tickets')}>Ver Tickets</button>
             </div>
 
             <div className="user-card faq-card">
@@ -240,7 +241,7 @@ export default function UserDashboard({ onLogout }) {
               </div>
               <h3>Preguntas Frecuentes</h3>
               <p>Encuentra respuestas rápidas a las dudas más comunes.</p>
-              <button className="card-button">Ver FAQ</button>
+              <button className="card-button" onClick={() => setActiveMenu('faq')}>Ver FAQ</button>
             </div>
           </div>
           
@@ -281,8 +282,11 @@ export default function UserDashboard({ onLogout }) {
               </div>
             ))}
           </div>
-          {['new-ticket', 'my-tickets'].includes(activeMenu) && (
-            <TicketList filter={{ usuarioId: 1 }} currentUserId={1} />
+          {activeMenu === 'new-ticket' && (
+            <TicketForm token={token} />
+          )}
+          {activeMenu === 'my-tickets' && (
+            <TicketList token={token} role={role} />
           )}
         </main>
       </div>


### PR DESCRIPTION
## Summary
- Pass authentication token and role to each dashboard component
- Make admin, technician, and user dashboard buttons navigate to functional sections
- Wire dashboards to show TicketList or TicketForm based on selected action

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6899e17364388329a21ac727cc46ed7c