### PR TITLE
feat: add role-based dashboard component

### DIFF
--- a/helpdesk-frontend/src/App.js
+++ b/helpdesk-frontend/src/App.js
@@ -2,9 +2,7 @@ import React, { useState } from 'react';
 import Login from './components/Login';
 import ChatBotWidget from './components/ChatBotWidget';
 import Register from './components/Register';
-import AdminDashboard from './components/AdminDashboard';
-import TechnicianDashboard from './components/TechnicianDashboard';
-import UserDashboard from './components/UserDashboard';
+import Dashboard from './components/Dashboard';
 import './App.css';
 
 function App() {
@@ -42,34 +40,12 @@ function App() {
     );
   }
 
-  if (rol === 'Solicitante') {
-    return (
-      <>
-        <UserDashboard onLogout={handleLogout} token={token} role={rol} />
-        <ChatBotWidget />
-      </>
-    );
-  }
-
-  if (rol === 'Tecnico') {
-    return (
-      <>
-        <TechnicianDashboard onLogout={handleLogout} token={token} role={rol} />
-        <ChatBotWidget />
-      </>
-    );
-  }
-
-  if (rol === 'Administrador') {
-    return (
-      <>
-        <AdminDashboard onLogout={handleLogout} token={token} role={rol} />
-        <ChatBotWidget />
-      </>
-    );
-  }
-
-  return <div>No tienes permisos</div>;
+  return (
+    <>
+      <Dashboard onLogout={handleLogout} token={token} role={rol} />
+      <ChatBotWidget />
+    </>
+  );
 }
 
 export default App;

--- a/helpdesk-frontend/src/components/Dashboard.css
+++ b/helpdesk-frontend/src/components/Dashboard.css
@@ -1,0 +1,60 @@
+.dashboard-wrapper {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 220px;
+  background: #f5f5f5;
+  padding: 1rem;
+  box-sizing: border-box;
+}
+
+.menu-btn {
+  display: block;
+  width: 100%;
+  padding: 0.5rem 1rem;
+  margin-bottom: 0.25rem;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 0.95rem;
+}
+
+.menu-btn.active {
+  font-weight: bold;
+}
+
+.menu-btn.logout {
+  margin-top: 1rem;
+  color: #d00;
+}
+
+.main-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.card-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.nav-card {
+  flex: 1 1 150px;
+  padding: 1rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  text-align: center;
+  cursor: pointer;
+  background: #fff;
+}
+
+.placeholder {
+  padding: 2rem;
+  text-align: center;
+  font-style: italic;
+  color: #666;
+}

--- a/helpdesk-frontend/src/components/Dashboard.jsx
+++ b/helpdesk-frontend/src/components/Dashboard.jsx
@@ -1,0 +1,105 @@
+import React, { useState } from 'react';
+import TicketList from './TicketList';
+import TicketForm from './TicketForm';
+import './Dashboard.css';
+
+/**
+ * Componente principal que renderiza los menús y vistas según el rol del usuario.
+ *
+ * Props:
+ *  - role: Rol del usuario autenticado
+ *  - token: Token de autenticación (no se usa directamente pero queda disponible)
+ *  - onLogout: Función para cerrar sesión
+ */
+export default function Dashboard({ role, token, onLogout }) {
+  // Configuración de menús y componentes por rol
+  const menuConfig = {
+    Administrador: [
+      { key: 'dashboard', label: 'Dashboard' },
+      { key: 'settings', label: 'Configuración' },
+      { key: 'reports', label: 'Reportes' },
+      { key: 'tickets', label: 'Tickets', component: <TicketList token={token} /> },
+      { key: 'users', label: 'Usuarios' }
+    ],
+    Tecnico: [
+      { key: 'dashboard', label: 'Dashboard' },
+      { key: 'assigned', label: 'Tickets asignados', component: <TicketList token={token} /> },
+      { key: 'new-report', label: 'Nuevo reporte', component: <TicketForm token={token} /> },
+      { key: 'history', label: 'Historial' },
+      { key: 'settings', label: 'Configuración' }
+    ],
+    Solicitante: [
+      { key: 'dashboard', label: 'Inicio' },
+      { key: 'new-ticket', label: 'Nuevo ticket', component: <TicketForm token={token} /> },
+      { key: 'my-tickets', label: 'Mis tickets', component: <TicketList token={token} /> },
+      { key: 'faq', label: 'FAQ' },
+      { key: 'settings', label: 'Configuración' }
+    ]
+  };
+
+  const menus = menuConfig[role] || [];
+  const [activeMenu, setActiveMenu] = useState(menus[0]?.key || '');
+
+  // Renderiza contenido principal según la sección activa
+  const renderContent = () => {
+    const current = menus.find(m => m.key === activeMenu);
+    if (!current) {
+      return <Placeholder label="Sección" />;
+    }
+    if (current.key === 'dashboard') {
+      return (
+        <div className="dashboard-home">
+          <h2>Bienvenido, {role}</h2>
+          <div className="card-grid">
+            {menus
+              .filter(m => m.key !== 'dashboard')
+              .map(m => (
+                <div
+                  key={m.key}
+                  className="nav-card"
+                  onClick={() => setActiveMenu(m.key)}
+                >
+                  <span>{m.label}</span>
+                </div>
+              ))}
+          </div>
+        </div>
+      );
+    }
+    if (current.component) {
+      return current.component;
+    }
+    return <Placeholder label={current.label} />;
+  };
+
+  return (
+    <div className="dashboard-wrapper">
+      <aside className="sidebar">
+        <nav>
+          {menus.map(item => (
+            <button
+              key={item.key}
+              className={`menu-btn ${activeMenu === item.key ? 'active' : ''}`}
+              onClick={() => setActiveMenu(item.key)}
+            >
+              {item.label}
+            </button>
+          ))}
+          <button className="menu-btn logout" onClick={onLogout}>
+            Cerrar sesión
+          </button>
+        </nav>
+      </aside>
+      <main className="main-content">{renderContent()}</main>
+    </div>
+  );
+}
+
+// Componente de marcador de posición para secciones no implementadas
+function Placeholder({ label }) {
+  return (
+    <div className="placeholder">
+      Sección "{label}" en construcción
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Dashboard component to handle role-based navigation with placeholders
- wire App to render unified Dashboard after login
- style dashboard layout

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6899e81d6f048329b4783cfc6f19a32d