### PR TITLE
feat: restore role dashboards with stateful navigation

### DIFF
--- a/helpdesk-frontend/src/App.js
+++ b/helpdesk-frontend/src/App.js
@@ -42,34 +42,25 @@ function App() {
     );
   }
 
-  if (rol === 'Solicitante') {
-    return (
-      <>
-        <UserDashboard onLogout={handleLogout} token={token} role={rol} />
-        <ChatBotWidget />
-      </>
-    );
+const renderDashboard = () => {
+  switch (rol) {
+    case 'Administrador':
+      return <AdminDashboard onLogout={handleLogout} token={token} role={rol} />;
+    case 'Tecnico':
+      return <TechnicianDashboard onLogout={handleLogout} token={token} role={rol} />;
+    case 'Solicitante':
+      return <UserDashboard onLogout={handleLogout} token={token} role={rol} />;
+    default:
+      return null;
   }
+};
 
-  if (rol === 'Tecnico') {
-    return (
-      <>
-        <TechnicianDashboard onLogout={handleLogout} token={token} role={rol} />
-        <ChatBotWidget />
-      </>
-    );
-  }
-
-  if (rol === 'Administrador') {
-    return (
-      <>
-        <AdminDashboard onLogout={handleLogout} token={token} role={rol} />
-        <ChatBotWidget />
-      </>
-    );
-  }
-
-  return <div>No tienes permisos</div>;
+  return (
+    <>
+      {renderDashboard()}
+      <ChatBotWidget />
+    </>
+  );
 }
 
 export default App;

--- a/helpdesk-frontend/src/components/AdminDashboard.css
+++ b/helpdesk-frontend/src/components/AdminDashboard.css
@@ -248,10 +248,13 @@
     border-top: 1px solid var(--gray-light);
   }
   
-  .notification-footer a {
+  .notification-footer button {
     color: var(--emi-blue);
     font-size: 0.85rem;
     text-decoration: none;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
   
   .user-profile {
@@ -344,7 +347,7 @@
     width: var(--sidebar-collapsed-width);
   }
   
-  .sidebar-collapsed .admin-sidebar nav ul li a span {
+  .sidebar-collapsed .admin-sidebar nav ul li button span {
     display: none;
   }
   
@@ -357,35 +360,39 @@
     margin-bottom: 0.25rem;
   }
   
-  .admin-sidebar nav ul li a {
+  .admin-sidebar nav ul li button {
     display: flex;
     align-items: center;
+    width: 100%;
     padding: 0.75rem 1.5rem;
     color: var(--dark);
-    text-decoration: none;
     font-size: 0.95rem;
     transition: var(--transition);
     position: relative;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
   }
-  
-  .admin-sidebar nav ul li a:hover {
+
+  .admin-sidebar nav ul li button:hover {
     background-color: var(--light);
     color: var(--emi-blue);
   }
-  
-  .admin-sidebar nav ul li a .icon {
+
+  .admin-sidebar nav ul li button .icon {
     margin-right: 1rem;
     font-size: 1.1rem;
     flex-shrink: 0;
     color: var(--gray);
   }
-  
-  .admin-sidebar nav ul li.active a {
+
+  .admin-sidebar nav ul li.active button {
     color: var(--emi-blue);
     background-color: rgba(30, 136, 229, 0.1);
   }
-  
-  .admin-sidebar nav ul li.active a::before {
+
+  .admin-sidebar nav ul li.active button::before {
     content: '';
     position: absolute;
     left: 0;
@@ -395,7 +402,7 @@
     background-color: var(--emi-blue);
     border-radius: 0 4px 4px 0;
   }
-  
+
   .admin-sidebar nav ul li.active .icon {
     color: var(--emi-blue);
   }
@@ -528,8 +535,11 @@
     text-decoration: none;
     transition: var(--transition);
     font-weight: 500;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
-  
+
   .view-all:hover {
     text-decoration: underline;
     color: var(--emi-blue-dark);

--- a/helpdesk-frontend/src/components/AdminDashboard.jsx
+++ b/helpdesk-frontend/src/components/AdminDashboard.jsx
@@ -72,9 +72,9 @@ export default function AdminDashboard({ onLogout, token, role }) {
                     </div>
                   ))}
                 </div>
-                <div className="notification-footer">
-                  <a href="#">Ver todas</a>
-                </div>
+              <div className="notification-footer">
+                <button type="button">Ver todas</button>
+              </div>
               </div>
             )}
           </div>
@@ -101,40 +101,35 @@ export default function AdminDashboard({ onLogout, token, role }) {
         <aside className="admin-sidebar">
           <nav>
             <ul>
-              <li 
-                className={activeMenu === 'dashboard' ? 'active' : ''}
-                onClick={() => setActiveMenu('dashboard')}
-              >
-                <FiHome className="icon" />
-                <a href="#">Dashboard</a>
+              <li className={activeMenu === 'dashboard' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('dashboard')}>
+                  <FiHome className="icon" />
+                  <span>Dashboard</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'settings' ? 'active' : ''}
-                onClick={() => setActiveMenu('settings')}
-              >
-                <FiSettings className="icon" />
-                <a href="#">Configuración</a>
+              <li className={activeMenu === 'settings' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('settings')}>
+                  <FiSettings className="icon" />
+                  <span>Configuración</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'reports' ? 'active' : ''}
-                onClick={() => setActiveMenu('reports')}
-              >
-                <FiPieChart className="icon" />
-                <a href="#">Reportes</a>
+              <li className={activeMenu === 'reports' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('reports')}>
+                  <FiPieChart className="icon" />
+                  <span>Reportes</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'tickets' ? 'active' : ''}
-                onClick={() => setActiveMenu('tickets')}
-              >
-                <FiMessageSquare className="icon" />
-                <a href="#">Tickets</a>
+              <li className={activeMenu === 'tickets' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('tickets')}>
+                  <FiMessageSquare className="icon" />
+                  <span>Tickets</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'users' ? 'active' : ''}
-                onClick={() => setActiveMenu('users')}
-              >
-                <FiUsers className="icon" />
-                <a href="#">Usuarios</a>
+              <li className={activeMenu === 'users' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('users')}>
+                  <FiUsers className="icon" />
+                  <span>Usuarios</span>
+                </button>
               </li>
             </ul>
           </nav>
@@ -142,129 +137,133 @@ export default function AdminDashboard({ onLogout, token, role }) {
 
         {/* Área principal */}
         <main className="admin-main">
-          <div className="welcome-section">
-            <h2>Bienvenido, <span>Administrador</span></h2>
-            <p className="last-access">Último acceso: Hoy a las {new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</p>
-          </div>
-          
-          {/* Estadísticas rápidas */}
-          <div className="quick-stats">
-            <div className="stat-card">
-              <div className="stat-icon users-stat">
-                <FiUsers />
+          {activeMenu === 'dashboard' && (
+            <>
+              <div className="welcome-section">
+                <h2>Bienvenido, <span>Administrador</span></h2>
+                <p className="last-access">Último acceso: Hoy a las {new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</p>
               </div>
-              <div className="stat-info">
-                <span className="stat-value">1,245</span>
-                <span className="stat-label">Usuarios</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon tickets-stat">
-                <FiMessageSquare />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">42</span>
-                <span className="stat-label">Tickets activos</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon solved-stat">
-                <FiMessageSquare />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">128</span>
-                <span className="stat-label">Resueltos</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon satisfaction-stat">
-                <FiPieChart />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">92%</span>
-                <span className="stat-label">Satisfacción</span>
-              </div>
-            </div>
-          </div>
-          
-          {/* Tarjetas de acción */}
-          <div className="section-title">
-            <h3>Acciones rápidas</h3>
-            <a href="#" className="view-all">Ver todo</a>
-          </div>
-          
-          <div className="card-container">
-            <div className="admin-card config-card">
-              <div className="card-icon">
-                <FiSettings />
-              </div>
-              <h3>Configurar Sistema</h3>
-              <p>Administrar roles y categorías del sistema.</p>
-              <button className="card-button" onClick={() => setActiveMenu('settings')}>Ir a Configuración</button>
-            </div>
 
-            <div className="admin-card reports-card">
-              <div className="card-icon">
-                <FiPieChart />
-              </div>
-              <h3>Ver Reportes</h3>
-              <p>Visualizar estadísticas de tickets y rendimiento.</p>
-              <button className="card-button" onClick={() => setActiveMenu('reports')}>Ver Reportes</button>
-            </div>
+              {/* Estadísticas rápidas */}
+              <div className="quick-stats">
+                <div className="stat-card">
+                  <div className="stat-icon users-stat">
+                    <FiUsers />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">1,245</span>
+                    <span className="stat-label">Usuarios</span>
+                  </div>
+                </div>
 
-            <div className="admin-card tickets-card">
-              <div className="card-icon">
-                <FiMessageSquare />
-              </div>
-              <h3>Asignar Tickets</h3>
-              <p>Asignar solicitudes a técnicos disponibles.</p>
-              <button className="card-button" onClick={() => setActiveMenu('tickets')}>Asignar Tickets</button>
-            </div>
+                <div className="stat-card">
+                  <div className="stat-icon tickets-stat">
+                    <FiMessageSquare />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">42</span>
+                    <span className="stat-label">Tickets activos</span>
+                  </div>
+                </div>
 
-            <div className="admin-card users-card">
-              <div className="card-icon">
-                <FiUsers />
+                <div className="stat-card">
+                  <div className="stat-icon solved-stat">
+                    <FiMessageSquare />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">128</span>
+                    <span className="stat-label">Resueltos</span>
+                  </div>
+                </div>
+
+                <div className="stat-card">
+                  <div className="stat-icon satisfaction-stat">
+                    <FiPieChart />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">92%</span>
+                    <span className="stat-label">Satisfacción</span>
+                  </div>
+                </div>
               </div>
-              <h3>Gestionar Usuarios</h3>
-              <p>Agregar, editar y eliminar cuentas de usuarios.</p>
-              <button className="card-button" onClick={() => setActiveMenu('users')}>Gestionar Usuarios</button>
-            </div>
-          </div>
-          
-          {/* Actividad reciente */}
-          <div className="section-title">
-            <h3>Actividad reciente</h3>
-            <a href="#" className="view-all">Ver todo</a>
-          </div>
-          
-          <div className="recent-activity">
-            <div className="activity-item">
-              <div className="activity-dot"></div>
-              <div className="activity-content">
-                <p>Nuevo usuario registrado: <strong>María González</strong></p>
-                <span className="activity-time">Hace 15 minutos</span>
+
+              {/* Tarjetas de acción */}
+              <div className="section-title">
+                <h3>Acciones rápidas</h3>
+                <button type="button" className="view-all">Ver todo</button>
               </div>
-            </div>
-            
-            <div className="activity-item">
-              <div className="activity-dot"></div>
-              <div className="activity-content">
-                <p>Ticket <strong>#TKT-00425</strong> asignado a técnico</p>
-                <span className="activity-time">Hace 32 minutos</span>
+
+              <div className="card-container">
+                <div className="admin-card config-card">
+                  <div className="card-icon">
+                    <FiSettings />
+                  </div>
+                  <h3>Configurar Sistema</h3>
+                  <p>Administrar roles y categorías del sistema.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('settings')}>Ir a Configuración</button>
+                </div>
+
+                <div className="admin-card reports-card">
+                  <div className="card-icon">
+                    <FiPieChart />
+                  </div>
+                  <h3>Ver Reportes</h3>
+                  <p>Visualizar estadísticas de tickets y rendimiento.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('reports')}>Ver Reportes</button>
+                </div>
+
+                <div className="admin-card tickets-card">
+                  <div className="card-icon">
+                    <FiMessageSquare />
+                  </div>
+                  <h3>Asignar Tickets</h3>
+                  <p>Asignar solicitudes a técnicos disponibles.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('tickets')}>Asignar Tickets</button>
+                </div>
+
+                <div className="admin-card users-card">
+                  <div className="card-icon">
+                    <FiUsers />
+                  </div>
+                  <h3>Gestionar Usuarios</h3>
+                  <p>Agregar, editar y eliminar cuentas de usuarios.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('users')}>Gestionar Usuarios</button>
+                </div>
               </div>
-            </div>
-            
-            <div className="activity-item">
-              <div className="activity-dot"></div>
-              <div className="activity-content">
-                <p>Reporte mensual generado automáticamente</p>
-                <span className="activity-time">Hace 2 horas</span>
+
+              {/* Actividad reciente */}
+              <div className="section-title">
+                <h3>Actividad reciente</h3>
+                <button type="button" className="view-all">Ver todo</button>
               </div>
-            </div>
-          </div>
+
+              <div className="recent-activity">
+                <div className="activity-item">
+                  <div className="activity-dot"></div>
+                  <div className="activity-content">
+                    <p>Nuevo usuario registrado: <strong>María González</strong></p>
+                    <span className="activity-time">Hace 15 minutos</span>
+                  </div>
+                </div>
+
+                <div className="activity-item">
+                  <div className="activity-dot"></div>
+                  <div className="activity-content">
+                    <p>Ticket <strong>#TKT-00425</strong> asignado a técnico</p>
+                    <span className="activity-time">Hace 32 minutos</span>
+                  </div>
+                </div>
+
+                <div className="activity-item">
+                  <div className="activity-dot"></div>
+                  <div className="activity-content">
+                    <p>Reporte mensual generado automáticamente</p>
+                    <span className="activity-time">Hace 2 horas</span>
+                  </div>
+                </div>
+              </div>
+            </>
+          )}
           {activeMenu === 'tickets' && (
             <TicketList token={token} role={role} />
           )}
@@ -272,10 +271,10 @@ export default function AdminDashboard({ onLogout, token, role }) {
             <div className="placeholder">Gestión de usuarios en construcción</div>
           )}
           {activeMenu === 'settings' && (
-            <div className="placeholder">Configuración del sistema</div>
+            <div className="placeholder">Configuración del sistema en construcción</div>
           )}
           {activeMenu === 'reports' && (
-            <div className="placeholder">Reportes del sistema</div>
+            <div className="placeholder">Reportes del sistema en construcción</div>
           )}
         </main>
       </div>

--- a/helpdesk-frontend/src/components/TechnicianDashboard.css
+++ b/helpdesk-frontend/src/components/TechnicianDashboard.css
@@ -248,10 +248,13 @@
     border-top: 1px solid var(--gray-light);
   }
   
-  .notification-footer a {
+  .notification-footer button {
     color: var(--tech-green);
     font-size: 0.85rem;
     text-decoration: none;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
   
   .user-profile {
@@ -344,7 +347,7 @@
     width: var(--sidebar-collapsed-width);
   }
   
-  .sidebar-collapsed .tech-sidebar nav ul li a span {
+  .sidebar-collapsed .tech-sidebar nav ul li button span {
     display: none;
   }
   
@@ -357,35 +360,39 @@
     margin-bottom: 0.25rem;
   }
   
-  .tech-sidebar nav ul li a {
+  .tech-sidebar nav ul li button {
     display: flex;
     align-items: center;
+    width: 100%;
     padding: 0.75rem 1.5rem;
     color: var(--dark);
-    text-decoration: none;
     font-size: 0.95rem;
     transition: var(--transition);
     position: relative;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
   }
-  
-  .tech-sidebar nav ul li a:hover {
+
+  .tech-sidebar nav ul li button:hover {
     background-color: var(--light);
     color: var(--tech-green);
   }
-  
-  .tech-sidebar nav ul li a .icon {
+
+  .tech-sidebar nav ul li button .icon {
     margin-right: 1rem;
     font-size: 1.1rem;
     flex-shrink: 0;
     color: var(--gray);
   }
-  
-  .tech-sidebar nav ul li.active a {
+
+  .tech-sidebar nav ul li.active button {
     color: var(--tech-green);
     background-color: rgba(16, 185, 129, 0.1);
   }
-  
-  .tech-sidebar nav ul li.active a::before {
+
+  .tech-sidebar nav ul li.active button::before {
     content: '';
     position: absolute;
     left: 0;
@@ -395,7 +402,7 @@
     background-color: var(--tech-green);
     border-radius: 0 4px 4px 0;
   }
-  
+
   .tech-sidebar nav ul li.active .icon {
     color: var(--tech-green);
   }
@@ -528,8 +535,11 @@
     text-decoration: none;
     transition: var(--transition);
     font-weight: 500;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
-  
+
   .view-all:hover {
     text-decoration: underline;
     color: var(--tech-green-dark);

--- a/helpdesk-frontend/src/components/TechnicianDashboard.jsx
+++ b/helpdesk-frontend/src/components/TechnicianDashboard.jsx
@@ -91,9 +91,9 @@ export default function TechnicianDashboard({ onLogout, token, role }) {
                     </div>
                   ))}
                 </div>
-                <div className="notification-footer">
-                  <a href="#">Ver todas</a>
-                </div>
+              <div className="notification-footer">
+                <button type="button">Ver todas</button>
+              </div>
               </div>
             )}
           </div>
@@ -120,40 +120,35 @@ export default function TechnicianDashboard({ onLogout, token, role }) {
         <aside className="tech-sidebar">
           <nav>
             <ul>
-              <li 
-                className={activeMenu === 'dashboard' ? 'active' : ''}
-                onClick={() => setActiveMenu('dashboard')}
-              >
-                <FiHome className="icon" />
-                <a href="#">Dashboard</a>
+              <li className={activeMenu === 'dashboard' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('dashboard')}>
+                  <FiHome className="icon" />
+                  <span>Dashboard</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'tickets' ? 'active' : ''}
-                onClick={() => setActiveMenu('tickets')}
-              >
-                <FiMessageSquare className="icon" />
-                <a href="#">Mis Tickets</a>
+              <li className={activeMenu === 'tickets' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('tickets')}>
+                  <FiMessageSquare className="icon" />
+                  <span>Mis Tickets</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'new' ? 'active' : ''}
-                onClick={() => setActiveMenu('new')}
-              >
-                <FiPlus className="icon" />
-                <a href="#">Nuevo Reporte</a>
+              <li className={activeMenu === 'new' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('new')}>
+                  <FiPlus className="icon" />
+                  <span>Nuevo Reporte</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'history' ? 'active' : ''}
-                onClick={() => setActiveMenu('history')}
-              >
-                <FiFileText className="icon" />
-                <a href="#">Historial</a>
+              <li className={activeMenu === 'history' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('history')}>
+                  <FiFileText className="icon" />
+                  <span>Historial</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'settings' ? 'active' : ''}
-                onClick={() => setActiveMenu('settings')}
-              >
-                <FiSettings className="icon" />
-                <a href="#">Configuración</a>
+              <li className={activeMenu === 'settings' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('settings')}>
+                  <FiSettings className="icon" />
+                  <span>Configuración</span>
+                </button>
               </li>
             </ul>
           </nav>
@@ -161,131 +156,141 @@ export default function TechnicianDashboard({ onLogout, token, role }) {
 
         {/* Área principal */}
         <main className="tech-main">
-          <div className="welcome-section">
-            <h2>Bienvenido, <span>Técnico</span></h2>
-            <p className="last-access">Último acceso: Hoy a las {new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</p>
-          </div>
-          
-          {/* Estadísticas rápidas */}
-          <div className="quick-stats">
-            <div className="stat-card">
-              <div className="stat-icon assigned-stat">
-                <FiMessageSquare />
+          {activeMenu === 'dashboard' && (
+            <>
+              <div className="welcome-section">
+                <h2>Bienvenido, <span>Técnico</span></h2>
+                <p className="last-access">Último acceso: Hoy a las {new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</p>
               </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.assigned}</span>
-                <span className="stat-label">Asignados</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon progress-stat">
-                <FiClock />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.inProgress}</span>
-                <span className="stat-label">En progreso</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon resolved-stat">
-                <FiCheckCircle />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.resolved}</span>
-                <span className="stat-label">Resueltos</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon overdue-stat">
-                <FiAlertCircle />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.overdue}</span>
-                <span className="stat-label">Vencidos</span>
-              </div>
-            </div>
-          </div>
-          
-          {/* Tarjetas de acción */}
-          <div className="section-title">
-            <h3>Acciones rápidas</h3>
-            <a href="#" className="view-all">Ver todo</a>
-          </div>
-          
-          <div className="card-container">
-            <div className="tech-card tickets-card">
-              <div className="card-icon">
-                <FiMessageSquare />
-              </div>
-              <h3>Ver Tickets Asignados</h3>
-              <p>Revisa los tickets que te han sido asignados para atención.</p>
-              <button className="card-button" onClick={() => setActiveMenu('tickets')}>Ver Tickets</button>
-            </div>
 
-            <div className="tech-card update-card">
-              <div className="card-icon">
-                <FiCheckCircle />
-              </div>
-              <h3>Actualizar Estados</h3>
-              <p>Marca los tickets como en progreso o resueltos.</p>
-              <button className="card-button" onClick={() => setActiveMenu('tickets')}>Actualizar</button>
-            </div>
+              {/* Estadísticas rápidas */}
+              <div className="quick-stats">
+                <div className="stat-card">
+                  <div className="stat-icon assigned-stat">
+                    <FiMessageSquare />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.assigned}</span>
+                    <span className="stat-label">Asignados</span>
+                  </div>
+                </div>
 
-            <div className="tech-card new-card">
-              <div className="card-icon">
-                <FiPlus />
-              </div>
-              <h3>Crear Reporte</h3>
-              <p>Genera un nuevo reporte de incidencia o solicitud.</p>
-              <button className="card-button" onClick={() => setActiveMenu('new')}>Nuevo Reporte</button>
-            </div>
-          </div>
-          
-          {/* Tickets recientes */}
-          <div className="section-title">
-            <h3>Tickets Recientes</h3>
-            <a href="#" className="view-all">Ver todos</a>
-          </div>
-          
-          <div className="tickets-table">
-            <div className="table-header">
-              <div className="header-item">ID Ticket</div>
-              <div className="header-item">Descripción</div>
-              <div className="header-item">Estado</div>
-              <div className="header-item">Prioridad</div>
-              <div className="header-item">Tiempo</div>
-              <div className="header-item">Acciones</div>
-            </div>
-            
-            {recentTickets.map(ticket => (
-              <div className="table-row" key={ticket.id}>
-                <div className="row-item">{ticket.id}</div>
-                <div className="row-item">{ticket.title}</div>
-                <div className="row-item">
-                  <span className={`status-badge ${ticket.status.toLowerCase().replace(' ', '-')}`}>
-                    {ticket.status}
-                  </span>
+                <div className="stat-card">
+                  <div className="stat-icon progress-stat">
+                    <FiClock />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.inProgress}</span>
+                    <span className="stat-label">En progreso</span>
+                  </div>
                 </div>
-                <div className="row-item">
-                  <span className={`priority-badge ${ticket.priority.toLowerCase()}`}>
-                    {ticket.priority}
-                  </span>
+
+                <div className="stat-card">
+                  <div className="stat-icon resolved-stat">
+                    <FiCheckCircle />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.resolved}</span>
+                    <span className="stat-label">Resueltos</span>
+                  </div>
                 </div>
-                <div className="row-item">{ticket.time}</div>
-                <div className="row-item">
-                  <button className="action-button">Ver</button>
+
+                <div className="stat-card">
+                  <div className="stat-icon overdue-stat">
+                    <FiAlertCircle />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.overdue}</span>
+                    <span className="stat-label">Vencidos</span>
+                  </div>
                 </div>
               </div>
-            ))}
-          </div>
+
+              {/* Tarjetas de acción */}
+              <div className="section-title">
+                <h3>Acciones rápidas</h3>
+                <button type="button" className="view-all">Ver todo</button>
+              </div>
+
+              <div className="card-container">
+                <div className="tech-card tickets-card">
+                  <div className="card-icon">
+                    <FiMessageSquare />
+                  </div>
+                  <h3>Ver Tickets Asignados</h3>
+                  <p>Revisa los tickets que te han sido asignados para atención.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('tickets')}>Ver Tickets</button>
+                </div>
+
+                <div className="tech-card update-card">
+                  <div className="card-icon">
+                    <FiCheckCircle />
+                  </div>
+                  <h3>Actualizar Estados</h3>
+                  <p>Marca los tickets como en progreso o resueltos.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('tickets')}>Actualizar</button>
+                </div>
+
+                <div className="tech-card new-card">
+                  <div className="card-icon">
+                    <FiPlus />
+                  </div>
+                  <h3>Crear Reporte</h3>
+                  <p>Genera un nuevo reporte de incidencia o solicitud.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('new')}>Nuevo Reporte</button>
+                </div>
+              </div>
+
+              {/* Tickets recientes */}
+              <div className="section-title">
+                <h3>Tickets Recientes</h3>
+                <button type="button" className="view-all">Ver todos</button>
+              </div>
+
+              <div className="tickets-table">
+                <div className="table-header">
+                  <div className="header-item">ID Ticket</div>
+                  <div className="header-item">Descripción</div>
+                  <div className="header-item">Estado</div>
+                  <div className="header-item">Prioridad</div>
+                  <div className="header-item">Tiempo</div>
+                  <div className="header-item">Acciones</div>
+                </div>
+
+                {recentTickets.map(ticket => (
+                  <div className="table-row" key={ticket.id}>
+                    <div className="row-item">{ticket.id}</div>
+                    <div className="row-item">{ticket.title}</div>
+                    <div className="row-item">
+                      <span className={`status-badge ${ticket.status.toLowerCase().replace(' ', '-')}`}>
+                        {ticket.status}
+                      </span>
+                    </div>
+                    <div className="row-item">
+                      <span className={`priority-badge ${ticket.priority.toLowerCase()}`}>
+                        {ticket.priority}
+                      </span>
+                    </div>
+                    <div className="row-item">{ticket.time}</div>
+                    <div className="row-item">
+                      <button className="action-button">Ver</button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
           {activeMenu === 'tickets' && (
             <TicketList token={token} role={role} />
           )}
           {activeMenu === 'new' && (
             <TicketForm token={token} />
+          )}
+          {activeMenu === 'history' && (
+            <div className="placeholder">Historial en construcción</div>
+          )}
+          {activeMenu === 'settings' && (
+            <div className="placeholder">Configuración en construcción</div>
           )}
         </main>
       </div>

--- a/helpdesk-frontend/src/components/UserDashboard.css
+++ b/helpdesk-frontend/src/components/UserDashboard.css
@@ -248,10 +248,13 @@
     border-top: 1px solid var(--gray-light);
   }
   
-  .notification-footer a {
+  .notification-footer button {
     color: var(--emi-blue);
     font-size: 0.85rem;
     text-decoration: none;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
   
   .user-profile {
@@ -344,7 +347,7 @@
     width: var(--sidebar-collapsed-width);
   }
   
-  .sidebar-collapsed .user-sidebar nav ul li a span {
+  .sidebar-collapsed .user-sidebar nav ul li button span {
     display: none;
   }
   
@@ -357,35 +360,39 @@
     margin-bottom: 0.25rem;
   }
   
-  .user-sidebar nav ul li a {
+  .user-sidebar nav ul li button {
     display: flex;
     align-items: center;
+    width: 100%;
     padding: 0.75rem 1.5rem;
     color: var(--dark);
-    text-decoration: none;
     font-size: 0.95rem;
     transition: var(--transition);
     position: relative;
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
   }
-  
-  .user-sidebar nav ul li a:hover {
+
+  .user-sidebar nav ul li button:hover {
     background-color: var(--light);
     color: var(--emi-blue);
   }
-  
-  .user-sidebar nav ul li a .icon {
+
+  .user-sidebar nav ul li button .icon {
     margin-right: 1rem;
     font-size: 1.1rem;
     flex-shrink: 0;
     color: var(--gray);
   }
-  
-  .user-sidebar nav ul li.active a {
+
+  .user-sidebar nav ul li.active button {
     color: var(--emi-blue);
     background-color: rgba(30, 136, 229, 0.1);
   }
-  
-  .user-sidebar nav ul li.active a::before {
+
+  .user-sidebar nav ul li.active button::before {
     content: '';
     position: absolute;
     left: 0;
@@ -395,7 +402,7 @@
     background-color: var(--emi-blue);
     border-radius: 0 4px 4px 0;
   }
-  
+
   .user-sidebar nav ul li.active .icon {
     color: var(--emi-blue);
   }
@@ -528,8 +535,11 @@
     text-decoration: none;
     transition: var(--transition);
     font-weight: 500;
+    background: none;
+    border: none;
+    cursor: pointer;
   }
-  
+
   .view-all:hover {
     text-decoration: underline;
     color: var(--emi-blue-dark);

--- a/helpdesk-frontend/src/components/UserDashboard.jsx
+++ b/helpdesk-frontend/src/components/UserDashboard.jsx
@@ -92,9 +92,9 @@ export default function UserDashboard({ onLogout, token, role }) {
                     </div>
                   ))}
                 </div>
-                <div className="notification-footer">
-                  <a href="#">Ver todas</a>
-                </div>
+              <div className="notification-footer">
+                <button type="button">Ver todas</button>
+              </div>
               </div>
             )}
           </div>
@@ -121,40 +121,35 @@ export default function UserDashboard({ onLogout, token, role }) {
         <aside className="user-sidebar">
           <nav>
             <ul>
-              <li 
-                className={activeMenu === 'dashboard' ? 'active' : ''}
-                onClick={() => setActiveMenu('dashboard')}
-              >
-                <FiHome className="icon" />
-                <a href="#">Inicio</a>
+              <li className={activeMenu === 'dashboard' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('dashboard')}>
+                  <FiHome className="icon" />
+                  <span>Inicio</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'new-ticket' ? 'active' : ''}
-                onClick={() => setActiveMenu('new-ticket')}
-              >
-                <FiPlus className="icon" />
-                <a href="#">Nuevo Ticket</a>
+              <li className={activeMenu === 'new-ticket' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('new-ticket')}>
+                  <FiPlus className="icon" />
+                  <span>Nuevo Ticket</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'my-tickets' ? 'active' : ''}
-                onClick={() => setActiveMenu('my-tickets')}
-              >
-                <FiMessageSquare className="icon" />
-                <a href="#">Mis Tickets</a>
+              <li className={activeMenu === 'my-tickets' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('my-tickets')}>
+                  <FiMessageSquare className="icon" />
+                  <span>Mis Tickets</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'faq' ? 'active' : ''}
-                onClick={() => setActiveMenu('faq')}
-              >
-                <FiHelpCircle className="icon" />
-                <a href="#">Preguntas Frecuentes</a>
+              <li className={activeMenu === 'faq' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('faq')}>
+                  <FiHelpCircle className="icon" />
+                  <span>Preguntas Frecuentes</span>
+                </button>
               </li>
-              <li 
-                className={activeMenu === 'settings' ? 'active' : ''}
-                onClick={() => setActiveMenu('settings')}
-              >
-                <FiSettings className="icon" />
-                <a href="#">Configuración</a>
+              <li className={activeMenu === 'settings' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('settings')}>
+                  <FiSettings className="icon" />
+                  <span>Configuración</span>
+                </button>
               </li>
             </ul>
           </nav>
@@ -162,131 +157,141 @@ export default function UserDashboard({ onLogout, token, role }) {
 
         {/* Área principal */}
         <main className="user-main">
-          <div className="welcome-section">
-            <h2>Bienvenido, <span>Estudiante</span></h2>
-            <p className="last-access">Último acceso: Hoy a las {new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</p>
-          </div>
-          
-          {/* Estadísticas rápidas */}
-          <div className="quick-stats">
-            <div className="stat-card">
-              <div className="stat-icon open-stat">
-                <FiMessageSquare />
+          {activeMenu === 'dashboard' && (
+            <>
+              <div className="welcome-section">
+                <h2>Bienvenido, <span>Estudiante</span></h2>
+                <p className="last-access">Último acceso: Hoy a las {new Date().toLocaleTimeString([], {hour: '2-digit', minute:'2-digit'})}</p>
               </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.open}</span>
-                <span className="stat-label">Abiertos</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon progress-stat">
-                <FiClock />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.inProgress}</span>
-                <span className="stat-label">En progreso</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon resolved-stat">
-                <FiCheckCircle />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.resolved}</span>
-                <span className="stat-label">Resueltos</span>
-              </div>
-            </div>
-            
-            <div className="stat-card">
-              <div className="stat-icon urgent-stat">
-                <FiAlertCircle />
-              </div>
-              <div className="stat-info">
-                <span className="stat-value">{ticketStats.urgent}</span>
-                <span className="stat-label">Urgentes</span>
-              </div>
-            </div>
-          </div>
-          
-          {/* Tarjetas de acción */}
-          <div className="section-title">
-            <h3>Acciones rápidas</h3>
-            <a href="#" className="view-all">Ver todo</a>
-          </div>
-          
-          <div className="card-container">
-            <div className="user-card new-ticket-card">
-              <div className="card-icon">
-                <FiPlus />
-              </div>
-              <h3>Crear Nuevo Ticket</h3>
-              <p>Reporta cualquier problema técnico que tengas con el sistema.</p>
-              <button className="card-button" onClick={() => setActiveMenu('new-ticket')}>Nuevo Ticket</button>
-            </div>
 
-            <div className="user-card check-status-card">
-              <div className="card-icon">
-                <FiMessageSquare />
-              </div>
-              <h3>Consultar Estado</h3>
-              <p>Revisa el estado actual de tus tickets reportados.</p>
-              <button className="card-button" onClick={() => setActiveMenu('my-tickets')}>Ver Tickets</button>
-            </div>
+              {/* Estadísticas rápidas */}
+              <div className="quick-stats">
+                <div className="stat-card">
+                  <div className="stat-icon open-stat">
+                    <FiMessageSquare />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.open}</span>
+                    <span className="stat-label">Abiertos</span>
+                  </div>
+                </div>
 
-            <div className="user-card faq-card">
-              <div className="card-icon">
-                <FiHelpCircle />
-              </div>
-              <h3>Preguntas Frecuentes</h3>
-              <p>Encuentra respuestas rápidas a las dudas más comunes.</p>
-              <button className="card-button" onClick={() => setActiveMenu('faq')}>Ver FAQ</button>
-            </div>
-          </div>
-          
-          {/* Tickets recientes */}
-          <div className="section-title">
-            <h3>Tickets Recientes</h3>
-            <a href="#" className="view-all">Ver todos</a>
-          </div>
-          
-          <div className="tickets-table">
-            <div className="table-header">
-              <div className="header-item">ID Ticket</div>
-              <div className="header-item">Descripción</div>
-              <div className="header-item">Estado</div>
-              <div className="header-item">Prioridad</div>
-              <div className="header-item">Tiempo</div>
-              <div className="header-item">Acciones</div>
-            </div>
-            
-            {recentTickets.map(ticket => (
-              <div className="table-row" key={ticket.id}>
-                <div className="row-item">{ticket.id}</div>
-                <div className="row-item">{ticket.title}</div>
-                <div className="row-item">
-                  <span className={`status-badge ${ticket.status.toLowerCase().replace(' ', '-')}`}>
-                    {ticket.status}
-                  </span>
+                <div className="stat-card">
+                  <div className="stat-icon progress-stat">
+                    <FiClock />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.inProgress}</span>
+                    <span className="stat-label">En progreso</span>
+                  </div>
                 </div>
-                <div className="row-item">
-                  <span className={`priority-badge ${ticket.priority.toLowerCase()}`}>
-                    {ticket.priority}
-                  </span>
+
+                <div className="stat-card">
+                  <div className="stat-icon resolved-stat">
+                    <FiCheckCircle />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.resolved}</span>
+                    <span className="stat-label">Resueltos</span>
+                  </div>
                 </div>
-                <div className="row-item">{ticket.time}</div>
-                <div className="row-item">
-                  <button className="action-button">Ver</button>
+
+                <div className="stat-card">
+                  <div className="stat-icon urgent-stat">
+                    <FiAlertCircle />
+                  </div>
+                  <div className="stat-info">
+                    <span className="stat-value">{ticketStats.urgent}</span>
+                    <span className="stat-label">Urgentes</span>
+                  </div>
                 </div>
               </div>
-            ))}
-          </div>
+
+              {/* Tarjetas de acción */}
+              <div className="section-title">
+                <h3>Acciones rápidas</h3>
+                <button type="button" className="view-all">Ver todo</button>
+              </div>
+
+              <div className="card-container">
+                <div className="user-card new-ticket-card">
+                  <div className="card-icon">
+                    <FiPlus />
+                  </div>
+                  <h3>Crear Nuevo Ticket</h3>
+                  <p>Reporta cualquier problema técnico que tengas con el sistema.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('new-ticket')}>Nuevo Ticket</button>
+                </div>
+
+                <div className="user-card check-status-card">
+                  <div className="card-icon">
+                    <FiMessageSquare />
+                  </div>
+                  <h3>Consultar Estado</h3>
+                  <p>Revisa el estado actual de tus tickets reportados.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('my-tickets')}>Ver Tickets</button>
+                </div>
+
+                <div className="user-card faq-card">
+                  <div className="card-icon">
+                    <FiHelpCircle />
+                  </div>
+                  <h3>Preguntas Frecuentes</h3>
+                  <p>Encuentra respuestas rápidas a las dudas más comunes.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('faq')}>Ver FAQ</button>
+                </div>
+              </div>
+
+              {/* Tickets recientes */}
+              <div className="section-title">
+                <h3>Tickets Recientes</h3>
+                <button type="button" className="view-all">Ver todos</button>
+              </div>
+
+              <div className="tickets-table">
+                <div className="table-header">
+                  <div className="header-item">ID Ticket</div>
+                  <div className="header-item">Descripción</div>
+                  <div className="header-item">Estado</div>
+                  <div className="header-item">Prioridad</div>
+                  <div className="header-item">Tiempo</div>
+                  <div className="header-item">Acciones</div>
+                </div>
+
+                {recentTickets.map(ticket => (
+                  <div className="table-row" key={ticket.id}>
+                    <div className="row-item">{ticket.id}</div>
+                    <div className="row-item">{ticket.title}</div>
+                    <div className="row-item">
+                      <span className={`status-badge ${ticket.status.toLowerCase().replace(' ', '-')}`}>
+                        {ticket.status}
+                      </span>
+                    </div>
+                    <div className="row-item">
+                      <span className={`priority-badge ${ticket.priority.toLowerCase()}`}>
+                        {ticket.priority}
+                      </span>
+                    </div>
+                    <div className="row-item">{ticket.time}</div>
+                    <div className="row-item">
+                      <button className="action-button">Ver</button>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
           {activeMenu === 'new-ticket' && (
             <TicketForm token={token} />
           )}
           {activeMenu === 'my-tickets' && (
             <TicketList token={token} role={role} />
+          )}
+          {activeMenu === 'faq' && (
+            <div className="placeholder">Sección de preguntas frecuentes en construcción</div>
+          )}
+          {activeMenu === 'settings' && (
+            <div className="placeholder">Configuración del usuario en construcción</div>
           )}
         </main>
       </div>


### PR DESCRIPTION
## Summary
- remove unified Dashboard and reinstate Admin, Technician, and User dashboards
- navigate via button-based sidebars and action cards that toggle `activeMenu`
- handle `Solicitante` role explicitly when rendering dashboards and show placeholders for unfinished sections

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_6899e81d6f048329b4783cfc6f19a32d