### PR TITLE
Enhance chatbot with EMI FAQs and quick suggestions

### DIFF
--- a/helpdesk-frontend/src/components/ChatBotWidget.jsx
+++ b/helpdesk-frontend/src/components/ChatBotWidget.jsx
@@ -4,9 +4,17 @@ import './ChatBotWidget.css';
 export default function ChatBotWidget() {
   const [isOpen, setIsOpen] = useState(false);
   const [messages, setMessages] = useState([
-    { 
-      text: "¡Hola! Soy el asistente de soporte de la EMI Cochabamba. ¿En qué puedo ayudarte?", 
-      sender: "bot" 
+    {
+      text: "¡Hola! Soy el asistente de soporte de la EMI Cochabamba. ¿En qué puedo ayudarte?",
+      sender: "bot",
+      buttons: [
+        { title: "Modalidades de admisión", payload: "Cuáles son las modalidades de Admisión a la EMI?" },
+        { title: "Requisitos", payload: "Cuáles son los requisitos para formar parte de la EMI?" },
+        { title: "Prueba PSA", payload: "Qué es la prueba de suficiencia académica PSA?" },
+        { title: "Libreta militar", payload: "Cómo obtener la libreta de Servicio Militar?" },
+        { title: "Carreras", payload: "Cuáles son las carreras con las que cuenta la EMI?" },
+        { title: "Horarios", payload: "Cuáles son los horarios de atención?" }
+      ]
     }
   ]);
   const [newMessage, setNewMessage] = useState('');

--- a/rasa-bot/actions/actions.py
+++ b/rasa-bot/actions/actions.py
@@ -163,12 +163,22 @@ class ActionResponderFAQ(Action):
             domain: Dict[Text, Any]) -> List[Dict[Text, Any]]:
         
         latest_message = tracker.latest_message.get('text').lower()
-        
+
         if "horario" in latest_message or "hora" in latest_message:
             dispatcher.utter_message(response="utter_faq_horarios")
+        elif "modalidad" in latest_message or "admis" in latest_message:
+            dispatcher.utter_message(response="utter_faq_modalidades")
+        elif "requisit" in latest_message or "document" in latest_message:
+            dispatcher.utter_message(response="utter_faq_requisitos")
+        elif "psa" in latest_message or "suficiencia" in latest_message:
+            dispatcher.utter_message(response="utter_faq_psa")
+        elif "libreta" in latest_message or "servicio militar" in latest_message:
+            dispatcher.utter_message(response="utter_faq_libreta")
+        elif "carrera" in latest_message or "programa" in latest_message:
+            dispatcher.utter_message(response="utter_faq_carreras")
         elif "contacto" in latest_message or "llamar" in latest_message:
             dispatcher.utter_message(response="utter_faq_contacto")
         else:
             dispatcher.utter_message(response="utter_default")
-        
+
         return []

--- a/rasa-bot/data/nlu.yml
+++ b/rasa-bot/data/nlu.yml
@@ -65,3 +65,9 @@ nlu:
     - quién es el jefe de soporte?
     - qué debo hacer si olvidé mi contraseña?
     - cómo solicito materiales?
+    - cuáles son las modalidades de admisión a la emi?
+    - qué requisitos necesito para ingresar a la emi?
+    - qué es la prueba de suficiencia académica psa?
+    - cómo obtengo la libreta de servicio militar en la emi?
+    - qué carreras ofrece la emi?
+    - cuáles son los horarios de atención?

--- a/rasa-bot/data/stories.yml
+++ b/rasa-bot/data/stories.yml
@@ -51,14 +51,14 @@ stories:
     - intent: preguntas_frecuentes
       entities:
         - "horarios"
-    - action: utter_faq_horarios
+    - action: action_responder_faq
 
 - story: pregunta frecuente contacto
   steps:
     - intent: preguntas_frecuentes
       entities:
         - "contacto"
-    - action: utter_faq_contacto
+    - action: action_responder_faq
 
 - story: flujo mixto consulta y reporte
   steps:

--- a/rasa-bot/domain.yml
+++ b/rasa-bot/domain.yml
@@ -34,8 +34,22 @@ responses:
     - text: "Consulta: {num_ticket} | Estado: {estado} | {comentario}"
 
   utter_faq_horarios:
-    - text: "Nuestro horario de atención es de lunes a viernes de 8:00 a 20:00, y sábados de 9:00 a 14:00."
-    - text: "Atención al público: L-V 8-20, Sáb 9-14. Soporte remoto 24/7 para emergencias."
+    - text: "Horarios de atención:\nLunes: 08:00 – 12:00, 14:30 – 16:00\nMartes: 08:00 – 18:30\nMiércoles: 08:00 – 16:00\nJueves: 08:00 – 16:00\nViernes: 08:00 – 16:00\nSábado y domingo: cerrado"
+
+  utter_faq_modalidades:
+    - text: "La EMI tiene tres modalidades de admisión:\n1. Preuniversitario regular (11 semanas).\n2. Preuniversitario intensivo (4 semanas).\n3. Prueba de suficiencia académica con nota mínima de 5.1/10."
+
+  utter_faq_requisitos:
+    - text: "Requisitos para ingresar a la EMI:\n- Aprobar una modalidad de admisión.\n- Fotocopia legalizada del diploma de bachiller.\n- Certificado de nacimiento.\n- Fotocopia de CI del estudiante y del tutor.\n- Croquis de domicilio y factura de luz o agua."
+
+  utter_faq_psa:
+    - text: "La PSA evalúa matemática, física y química.\nInscripción: Bs. 100, hasta el 24 de enero.\nSe rinde el 25-27 de enero en la mañana. Requisitos: CI, diploma de bachiller y boleta de depósito al Banco Unión."
+
+  utter_faq_libreta:
+    - text: "La formación militar en la EMI es voluntaria, pero permite obtener la libreta con grado de reserva.\nSe realiza en los dos primeros semestres (sábados por la mañana).\nEl estudiante no debe tener más de 22 años al ingresar."
+
+  utter_faq_carreras:
+    - text: "La EMI ofrece carreras en cinco unidades académicas.\nLicenciaturas: Civil, Geográfica, Sistemas, Industrial, Agronómica, Comercial, Agroindustrial, Ambiental, Petrolera, Mecatrónica, Telecomunicaciones, Financiera y más.\nTécnico Superior: Informática, Sistemas Electrónicos, Energías Renovables, Construcción Civil, Diseño Gráfico."
 
   utter_faq_contacto:
     - text: "Puedes contactar al área técnica al teléfono 1234567 o al correo soporte@emi.edu.bo"


### PR DESCRIPTION
## Summary
- Add quick-reply FAQ suggestions to chatbot widget
- Expand Rasa training data and responses with EMI admission FAQ content
- Extend FAQ action handling for new categories

## Testing
- `npm test -- --watchAll=false`
- `rasa data validate` *(failed: command not found, attempt to install rasa failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a226733848329b23c0eb0c9c5a5be