### PR TITLE
Add missing slot mapping for fecha_actualizacion

### DIFF
--- a/rasa-bot/domain.yml
+++ b/rasa-bot/domain.yml
@@ -99,6 +99,8 @@ slots:
   fecha_actualizacion:
     type: text
     influence_conversation: false
+    mappings:
+    - type: custom
 
 actions:
   - action_validar_problema


### PR DESCRIPTION
## Summary
- add custom mapping for `fecha_actualizacion` slot to satisfy Rasa domain schema

## Testing
- `rasa data validate` *(fails: command not found)*
- `pip install rasa==3.1.0` *(fails: Could not find a version that satisfies the requirement rasa==3.1.0)*

------
https://chatgpt.com/codex/tasks/task_e_689a28f8f45c83299a4811bb5ab73c6a