### PR TITLE
Fix Rasa configuration to remove unused English components

### DIFF
--- a/rasa-bot/data/rules.yml
+++ b/rasa-bot/data/rules.yml
@@ -2,12 +2,7 @@ version: "3.1"
 
 rules:
 
-- rule: Say goodbye anytime the user says goodbye
+- rule: Responder al despedirse
   steps:
-  - intent: goodbye
-  - action: utter_goodbye
-
-- rule: Say 'I am a bot' anytime the user challenges
-  steps:
-  - intent: bot_challenge
-  - action: utter_iamabot
+  - intent: despedirse
+  - action: utter_despedirse

--- a/rasa-bot/data/stories.yml
+++ b/rasa-bot/data/stories.yml
@@ -68,4 +68,8 @@ stories:
     - action: action_responder_faq
     - intent: registrar_problema
     - action: utter_pedir_detalles
-    - intent: registrar
+    - intent: registrar_problema
+    - action: action_crear_ticket
+    - action: utter_confirmar_ticket
+    - intent: despedirse
+    - action: utter_despedirse

--- a/rasa-bot/tests/test_stories.yml
+++ b/rasa-bot/tests/test_stories.yml
@@ -1,91 +1,13 @@
-#### This file contains tests to evaluate that your bot behaves as expected.
-#### If you want to learn more, please see the docs: https://rasa.com/docs/rasa/testing-your-assistant
+version: "3.1"
 
 stories:
-- story: happy path 1
+- story: saludo y despedida
   steps:
   - user: |
-      hello there!
-    intent: greet
-  - action: utter_greet
+      hola
+    intent: saludar
+  - action: utter_saludar
   - user: |
-      amazing
-    intent: mood_great
-  - action: utter_happy
-
-- story: happy path 2
-  steps:
-  - user: |
-      hello there!
-    intent: greet
-  - action: utter_greet
-  - user: |
-      amazing
-    intent: mood_great
-  - action: utter_happy
-  - user: |
-      bye-bye!
-    intent: goodbye
-  - action: utter_goodbye
-
-- story: sad path 1
-  steps:
-  - user: |
-      hello
-    intent: greet
-  - action: utter_greet
-  - user: |
-      not good
-    intent: mood_unhappy
-  - action: utter_cheer_up
-  - action: utter_did_that_help
-  - user: |
-      yes
-    intent: affirm
-  - action: utter_happy
-
-- story: sad path 2
-  steps:
-  - user: |
-      hello
-    intent: greet
-  - action: utter_greet
-  - user: |
-      not good
-    intent: mood_unhappy
-  - action: utter_cheer_up
-  - action: utter_did_that_help
-  - user: |
-      not really
-    intent: deny
-  - action: utter_goodbye
-
-- story: sad path 3
-  steps:
-  - user: |
-      hi
-    intent: greet
-  - action: utter_greet
-  - user: |
-      very terrible
-    intent: mood_unhappy
-  - action: utter_cheer_up
-  - action: utter_did_that_help
-  - user: |
-      no
-    intent: deny
-  - action: utter_goodbye
-
-- story: say goodbye
-  steps:
-  - user: |
-      bye-bye!
-    intent: goodbye
-  - action: utter_goodbye
-
-- story: bot challenge
-  steps:
-  - user: |
-      are you a bot?
-    intent: bot_challenge
-  - action: utter_iamabot
+      adiós
+    intent: despedirse
+  - action: utter_despedirse


### PR DESCRIPTION
## Summary
- replace default rules with Spanish version and remove missing action
- complete mixed story flow with ticket creation and goodbye
- simplify test stories to match Spanish intents

## Testing
- `pip install rasa` *(fails: Could not connect to proxy)*
- `rasa train` *(command not found)*
- `pre-commit run --files rasa-bot/data/rules.yml rasa-bot/data/stories.yml rasa-bot/tests/test_stories.yml` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2e0c716483298bfcb1a8c34af6cc