### PR TITLE
feat: add role-based prompts and enlarge chatbot

### DIFF
--- a/helpdesk-frontend/src/components/ChatBotWidget.css
+++ b/helpdesk-frontend/src/components/ChatBotWidget.css
@@ -18,8 +18,8 @@
   }
   
   .chatbot-window {
-    width: 300px;
-    height: 400px;
+    width: 380px;
+    height: 520px;
     background: white;
     border-radius: 10px;
     box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);

--- a/rasa-bot/data/nlu.yml
+++ b/rasa-bot/data/nlu.yml
@@ -27,18 +27,23 @@ nlu:
     - nos vemos mañana
     - que descanses
 
-- intent: registrar_problema
-  examples: |
-    - tengo un problema con [el proyector](equipo)
-    - no funciona [el internet](equipo)
-    - [la impresora](equipo) no imprime
-    - hay fallas en [el sistema eléctrico](equipo)
-    - necesito reportar un fallo en [el laboratorio 3](ubicacion)
-    - [las computadoras](equipo) del aula 4 no encienden
-    - el [software](equipo) de diseño se cierra solo
-    - hay un problema en [el aire acondicionado](equipo) del [aula 202](ubicacion)
-    - [el servidor](equipo) no responde
-    - [el cañón proyector](equipo) no muestra imagen
+  - intent: registrar_problema
+    examples: |
+      - tengo un problema con [el proyector](equipo)
+      - no funciona [el internet](equipo)
+      - [la impresora](equipo) no imprime
+      - hay fallas en [el sistema eléctrico](equipo)
+      - necesito reportar un fallo en [el laboratorio 3](ubicacion)
+      - [las computadoras](equipo) del aula 4 no encienden
+      - el [software](equipo) de diseño se cierra solo
+      - hay un problema en [el aire acondicionado](equipo) del [aula 202](ubicacion)
+      - [el servidor](equipo) no responde
+      - [el cañón proyector](equipo) no muestra imagen
+      - no puedo iniciar sesión en el sistema
+      - tengo problemas de inicio de sesión
+      - mi dispositivo no enciende
+      - no puedo cargar las notas en el sistema
+      - necesito ayuda con el acceso a la plataforma
 
 - intent: consultar_estado
   examples: |


### PR DESCRIPTION
## Summary
- extend chatbot greeting with role selection and FAQ suggestions
- add role-specific problem options and enlarge widget window
- expand NLU examples for login and device issues

## Testing
- `npm test -- --watchAll=false`
- `rasa test --nlu` *(fails: command not found, attempted install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b3928e9c8329b153b4d2c17dbe73