### PR TITLE
Integrate chatbot ticket creation with user accounts

### DIFF
--- a/helpdesk-frontend/src/App.js
+++ b/helpdesk-frontend/src/App.js
@@ -7,9 +7,28 @@ import TechnicianDashboard from './components/TechnicianDashboard';
 import UserDashboard from './components/UserDashboard';
 import './App.css';
 
+// Extrae el ID de usuario desde un JWT sin validarlo en el cliente
+function getUserIdFromToken(token) {
+  if (!token) return null;
+  try {
+    const payload = JSON.parse(atob(token.split('.')[1]));
+    return (
+      payload['nameid'] ||
+      payload['http://schemas.xmlsoap.org/ws/2005/05/identity/claims/nameidentifier'] ||
+      payload['sub'] ||
+      null
+    );
+  } catch (e) {
+    return null;
+  }
+}
+
 function App() {
   const [token, setToken] = useState(localStorage.getItem('token') || null);
   const [rol, setRol] = useState(localStorage.getItem('rol') || null);
+  const [userId, setUserId] = useState(
+    localStorage.getItem('userId') || getUserIdFromToken(localStorage.getItem('token'))
+  );
   const [showRegister, setShowRegister] = useState(false);
   const validRoles = ['Solicitante', 'Tecnico', 'Administrador'];
 
@@ -17,15 +36,19 @@ function App() {
     const normalizedRole = rol
       ? rol.charAt(0).toUpperCase() + rol.slice(1).toLowerCase()
       : '';
+    const id = getUserIdFromToken(token);
     setToken(token);
     setRol(normalizedRole);
+    setUserId(id);
     localStorage.setItem('token', token);
     localStorage.setItem('rol', normalizedRole);
+    if (id) localStorage.setItem('userId', id);
   };
 
   const handleLogout = () => {
     setToken(null);
     setRol(null);
+    setUserId(null);
     localStorage.clear();
   };
 
@@ -37,7 +60,7 @@ function App() {
         ) : (
           <Login onLogin={handleLogin} onShowRegister={() => setShowRegister(true)} />
         )}
-        <ChatBotWidget />
+        <ChatBotWidget userId={userId} />
       </div>
     );
   }
@@ -58,7 +81,7 @@ function App() {
   return (
     <>
       {renderDashboard()}
-      <ChatBotWidget />
+      <ChatBotWidget userId={userId} />
     </>
   );
 }

--- a/helpdesk-frontend/src/components/ChatBotWidget.jsx
+++ b/helpdesk-frontend/src/components/ChatBotWidget.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import './ChatBotWidget.css';
 
-export default function ChatBotWidget() {
+export default function ChatBotWidget({ userId }) {
   const [isOpen, setIsOpen] = useState(false);
   const [selectedRole, setSelectedRole] = useState(null);
   const [messages, setMessages] = useState([
@@ -33,7 +33,9 @@ export default function ChatBotWidget() {
   ]);
   const [newMessage, setNewMessage] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [sessionId] = useState('user_' + Math.random().toString(36).substr(2, 9));
+  const [sessionId] = useState(() =>
+    userId ? String(userId) : 'guest_' + Math.random().toString(36).substr(2, 9)
+  );
   const messagesEndRef = useRef(null);
 
   const RASA_ENDPOINT = 'http://localhost:5005/webhooks/rest/webhook';

--- a/helpdesk-frontend/src/components/TicketList.jsx
+++ b/helpdesk-frontend/src/components/TicketList.jsx
@@ -89,31 +89,35 @@ function TicketList({ token, role }) {
     <div>
       <h2>Tickets</h2>
       {role === 'Administrador' && <TicketForm token={token} onCreated={fetchTickets} />}
-      <ul>
-        {tickets.map(ticket => (
-          <li key={ticket.id} style={{ marginBottom: '1em' }}>
-            <strong>#{ticket.id} {ticket.titulo}</strong> - {ticket.estado}
-            <p>{ticket.descripcion}</p>
-            {role === 'Administrador' && (
-              <>
-                <button onClick={() => handleAssign(ticket.id)}>Asignar</button>
-                <button onClick={() => handleEdit(ticket)}>Editar</button>
-                <button onClick={() => handleDelete(ticket.id)}>Eliminar</button>
-              </>
-            )}
-            {role === 'Tecnico' && (
-              <select
-                value={ticket.estado}
-                onChange={(e) => handleStatusChange(ticket.id, e.target.value)}
-              >
-                {estados.map(e => (
-                  <option key={e.value} value={e.value}>{e.label}</option>
-                ))}
-              </select>
-            )}
-          </li>
-        ))}
-      </ul>
+      {tickets.length === 0 ? (
+        <p>No tienes tickets registrados.</p>
+      ) : (
+        <ul>
+          {tickets.map(ticket => (
+            <li key={ticket.id} style={{ marginBottom: '1em' }}>
+              <strong>#{ticket.id} {ticket.titulo}</strong> - {ticket.estado}
+              <p>{ticket.descripcion}</p>
+              {role === 'Administrador' && (
+                <>
+                  <button onClick={() => handleAssign(ticket.id)}>Asignar</button>
+                  <button onClick={() => handleEdit(ticket)}>Editar</button>
+                  <button onClick={() => handleDelete(ticket.id)}>Eliminar</button>
+                </>
+              )}
+              {role === 'Tecnico' && (
+                <select
+                  value={ticket.estado}
+                  onChange={(e) => handleStatusChange(ticket.id, e.target.value)}
+                >
+                  {estados.map(e => (
+                    <option key={e.value} value={e.value}>{e.label}</option>
+                  ))}
+                </select>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Decode JWT on the frontend to obtain user ID and pass it to the chatbot widget
- Use user ID as Rasa session ID so chatbot-created tickets belong to the logged-in user
- Show a message when the user has no tickets in "Mis Tickets"

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9c0d8adac8329bc561207a13d7aaa