### PR TITLE
Filtrar tickets por usuario con estilos

### DIFF
--- a/helpdesk-frontend/src/components/TicketList.css
+++ b/helpdesk-frontend/src/components/TicketList.css
@@ -1,0 +1,37 @@
+.ticket-list-container {
+  max-width: 600px;
+  margin: 0 auto;
+}
+
+.ticket-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.ticket-item {
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 1rem;
+  margin-bottom: 1rem;
+}
+
+.ticket-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.ticket-status {
+  font-size: 0.9rem;
+  padding: 0.2rem 0.5rem;
+  background: #e0e0e0;
+  border-radius: 3px;
+}
+
+.ticket-actions button,
+.ticket-actions select {
+  margin-right: 0.5rem;
+}

--- a/helpdesk-frontend/src/components/TicketList.jsx
+++ b/helpdesk-frontend/src/components/TicketList.jsx
@@ -1,10 +1,23 @@
 import React, { useEffect, useState } from 'react';
 import TicketForm from './TicketForm';
+import './TicketList.css';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5131/api';
 
-function TicketList({ token, role }) {
+function TicketList({ token, role = 'Solicitante' }) {
   const [tickets, setTickets] = useState([]);
+  const [userId, setUserId] = useState(null);
+
+  useEffect(() => {
+    if (!token) return;
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      const id = payload?.nameid || payload?.sub || payload?.userId || payload?.id;
+      setUserId(id ? Number(id) : null);
+    } catch {
+      setUserId(null);
+    }
+  }, [token]);
 
   const fetchTickets = async () => {
     const response = await fetch(`${API_URL}/tickets`, {
@@ -85,34 +98,44 @@ function TicketList({ token, role }) {
     { value: 'Resuelto', label: 'Resuelto' }
   ];
 
+  const visibleTickets =
+    role === 'Solicitante' && userId
+      ? tickets.filter(t => t.usuarioId === userId)
+      : tickets;
+
   return (
-    <div>
+    <div className="ticket-list-container">
       <h2>Tickets</h2>
       {role === 'Administrador' && <TicketForm token={token} onCreated={fetchTickets} />}
-      {tickets.length === 0 ? (
+      {visibleTickets.length === 0 ? (
         <p>No tienes tickets registrados.</p>
       ) : (
-        <ul>
-          {tickets.map(ticket => (
-            <li key={ticket.id} style={{ marginBottom: '1em' }}>
-              <strong>#{ticket.id} {ticket.titulo}</strong> - {ticket.estado}
+        <ul className="ticket-list">
+          {visibleTickets.map(ticket => (
+            <li key={ticket.id} className="ticket-item">
+              <div className="ticket-header">
+                <strong>#{ticket.id} {ticket.titulo}</strong>
+                <span className="ticket-status">{ticket.estado}</span>
+              </div>
               <p>{ticket.descripcion}</p>
               {role === 'Administrador' && (
-                <>
+                <div className="ticket-actions">
                   <button onClick={() => handleAssign(ticket.id)}>Asignar</button>
                   <button onClick={() => handleEdit(ticket)}>Editar</button>
                   <button onClick={() => handleDelete(ticket.id)}>Eliminar</button>
-                </>
+                </div>
               )}
               {role === 'Tecnico' && (
-                <select
-                  value={ticket.estado}
-                  onChange={(e) => handleStatusChange(ticket.id, e.target.value)}
-                >
-                  {estados.map(e => (
-                    <option key={e.value} value={e.value}>{e.label}</option>
-                  ))}
-                </select>
+                <div className="ticket-actions">
+                  <select
+                    value={ticket.estado}
+                    onChange={(e) => handleStatusChange(ticket.id, e.target.value)}
+                  >
+                    {estados.map(e => (
+                      <option key={e.value} value={e.value}>{e.label}</option>
+                    ))}
+                  </select>
+                </div>
               )}
             </li>
           ))}


### PR DESCRIPTION
## Summary
- Filtra los tickets para mostrar solo los creados por el usuario actual.
- Agrega estilos básicos a la lista de tickets.

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9cdb1e5648329bd7f99415a0ddfdd