### PR TITLE
feat: add ticket list tab for admin

### DIFF
--- a/helpdesk-frontend/src/components/AdminDashboard.jsx
+++ b/helpdesk-frontend/src/components/AdminDashboard.jsx
@@ -120,10 +120,10 @@ export default function AdminDashboard({ onLogout, token, role }) {
                   <span>Reportes</span>
                 </button>
               </li>
-              <li className={activeMenu === 'tickets' ? 'active' : ''}>
-                <button type="button" onClick={() => setActiveMenu('tickets')}>
+              <li className={activeMenu === 'ticket-list' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('ticket-list')}>
                   <FiMessageSquare className="icon" />
-                  <span>Tickets</span>
+                  <span>Lista de Tickets</span>
                 </button>
               </li>
               <li className={activeMenu === 'users' ? 'active' : ''}>
@@ -217,9 +217,9 @@ export default function AdminDashboard({ onLogout, token, role }) {
                   <div className="card-icon">
                     <FiMessageSquare />
                   </div>
-                  <h3>Asignar Tickets</h3>
-                  <p>Asignar solicitudes a técnicos disponibles.</p>
-                  <button className="card-button" onClick={() => setActiveMenu('tickets')}>Asignar Tickets</button>
+                  <h3>Ver Tickets</h3>
+                  <p>Revisar todas las solicitudes registradas.</p>
+                  <button className="card-button" onClick={() => setActiveMenu('ticket-list')}>Ver Tickets</button>
                 </div>
 
                 <div className="admin-card users-card">
@@ -265,7 +265,7 @@ export default function AdminDashboard({ onLogout, token, role }) {
               </div>
             </>
           )}
-          {activeMenu === 'tickets' && (
+          {activeMenu === 'ticket-list' && (
             <TicketList token={token} role={role} />
           )}
           {activeMenu === 'users' && (<UserManagement token={token} />)}

--- a/helpdesk-frontend/src/components/TicketList.css
+++ b/helpdesk-frontend/src/components/TicketList.css
@@ -1,37 +1,26 @@
 .ticket-list-container {
-  max-width: 600px;
+  max-width: 800px;
   margin: 0 auto;
 }
 
-.ticket-list {
-  list-style: none;
-  padding: 0;
-  margin: 0;
+.ticket-table {
+  width: 100%;
+  border-collapse: collapse;
 }
 
-.ticket-item {
-  background: #f9f9f9;
+.ticket-table th,
+.ticket-table td {
   border: 1px solid #ddd;
-  border-radius: 4px;
-  padding: 1rem;
-  margin-bottom: 1rem;
+  padding: 0.5rem;
+  text-align: left;
 }
 
-.ticket-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 0.5rem;
-}
-
-.ticket-status {
-  font-size: 0.9rem;
-  padding: 0.2rem 0.5rem;
-  background: #e0e0e0;
-  border-radius: 3px;
+.ticket-table th {
+  background: #f9f9f9;
 }
 
 .ticket-actions button,
 .ticket-actions select {
   margin-right: 0.5rem;
 }
+

--- a/helpdesk-frontend/src/components/TicketList.jsx
+++ b/helpdesk-frontend/src/components/TicketList.jsx
@@ -110,36 +110,47 @@ function TicketList({ token, role = 'Solicitante' }) {
       {visibleTickets.length === 0 ? (
         <p>No tienes tickets registrados.</p>
       ) : (
-        <ul className="ticket-list">
-          {visibleTickets.map(ticket => (
-            <li key={ticket.id} className="ticket-item">
-              <div className="ticket-header">
-                <strong>#{ticket.id} {ticket.titulo}</strong>
-                <span className="ticket-status">{ticket.estado}</span>
-              </div>
-              <p>{ticket.descripcion}</p>
-              {role === 'Administrador' && (
-                <div className="ticket-actions">
-                  <button onClick={() => handleAssign(ticket.id)}>Asignar</button>
-                  <button onClick={() => handleEdit(ticket)}>Editar</button>
-                  <button onClick={() => handleDelete(ticket.id)}>Eliminar</button>
-                </div>
-              )}
-              {role === 'Tecnico' && (
-                <div className="ticket-actions">
-                  <select
-                    value={ticket.estado}
-                    onChange={(e) => handleStatusChange(ticket.id, e.target.value)}
-                  >
-                    {estados.map(e => (
-                      <option key={e.value} value={e.value}>{e.label}</option>
-                    ))}
-                  </select>
-                </div>
-              )}
-            </li>
-          ))}
-        </ul>
+        <table className="ticket-table">
+          <thead>
+            <tr>
+              <th>ID</th>
+              <th>Título</th>
+              <th>Descripción</th>
+              <th>Estado</th>
+              {role === 'Administrador' && <th>Acciones</th>}
+              {role === 'Tecnico' && <th>Cambiar estado</th>}
+            </tr>
+          </thead>
+          <tbody>
+            {visibleTickets.map(ticket => (
+              <tr key={ticket.id}>
+                <td>{ticket.id}</td>
+                <td>{ticket.titulo}</td>
+                <td>{ticket.descripcion}</td>
+                <td>{ticket.estado}</td>
+                {role === 'Administrador' && (
+                  <td className="ticket-actions">
+                    <button onClick={() => handleAssign(ticket.id)}>Asignar</button>
+                    <button onClick={() => handleEdit(ticket)}>Editar</button>
+                    <button onClick={() => handleDelete(ticket.id)}>Eliminar</button>
+                  </td>
+                )}
+                {role === 'Tecnico' && (
+                  <td className="ticket-actions">
+                    <select
+                      value={ticket.estado}
+                      onChange={(e) => handleStatusChange(ticket.id, e.target.value)}
+                    >
+                      {estados.map(e => (
+                        <option key={e.value} value={e.value}>{e.label}</option>
+                      ))}
+                    </select>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- display tickets in a table with admin actions
- add "Lista de Tickets" tab to admin dashboard
- style table for ticket list

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9d6405d3883299492256041eaa54f