### PR TITLE
fix: prevent JSON cycles in ticket serialization

### DIFF
--- a/HelpDeskAPI/Models/ChatMessage.cs
+++ b/HelpDeskAPI/Models/ChatMessage.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace HelpDeskAPI.Models
 {
@@ -11,6 +12,7 @@ namespace HelpDeskAPI.Models
         public int TicketId { get; set; }
 
         [ForeignKey("TicketId")]
+        [JsonIgnore]
         public Ticket? Ticket { get; set; }
 
         [Required]

--- a/HelpDeskAPI/Models/User.cs
+++ b/HelpDeskAPI/Models/User.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.Json.Serialization;
 
 namespace HelpDeskAPI.Models
 {
@@ -20,10 +21,13 @@ namespace HelpDeskAPI.Models
         [Required]
         public string Rol { get; set; } = string.Empty; // Roles: "Administrador", "Tecnico", "Solicitante"
 
+        [JsonIgnore]
         public ICollection<Ticket> TicketsCreados { get; set; } = new List<Ticket>();
 
+        [JsonIgnore]
         public ICollection<Ticket> TicketsAsignados { get; set; } = new List<Ticket>();
 
+        [JsonIgnore]
         public ICollection<ChatMessage> MensajesEnviados { get; set; } = new List<ChatMessage>();
     }
 }

--- a/HelpDeskAPI/Program.cs
+++ b/HelpDeskAPI/Program.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.IdentityModel.Tokens;
 using System.Text;
+using System.Text.Json.Serialization;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -53,8 +54,11 @@ builder.Services.AddAuthentication(options =>
     };
 });
 
-// 👮‍♂️ Habilitar controladores
-builder.Services.AddControllers();
+// 👮‍♂️ Habilitar controladores y evitar ciclos de referencia en JSON
+builder.Services.AddControllers().AddJsonOptions(options =>
+{
+    options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.IgnoreCycles;
+});
 
 // 🧪 Habilitar Swagger (documentación de API REST)
 builder.Services.AddEndpointsApiExplorer();


### PR DESCRIPTION
## Summary
- avoid circular references by configuring controller JSON options
- ignore navigation properties that caused cycles in User and ChatMessage models

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9da790f188329bfdfb0d553baf396