### PR TITLE
Add ticket creation section and improve table contrast

### DIFF
--- a/helpdesk-frontend/src/components/AdminDashboard.jsx
+++ b/helpdesk-frontend/src/components/AdminDashboard.jsx
@@ -5,6 +5,7 @@ import {
   FiUsers,
   FiPieChart,
   FiMessageSquare,
+  FiPlusCircle,
   FiLogOut,
   FiBell,
   FiHome,
@@ -13,6 +14,7 @@ import {
   FiX
 } from 'react-icons/fi';
 import TicketTable from './TicketTable';
+import TicketForm from './TicketForm';
 import UserManagement from './UserManagement';
 
 export default function AdminDashboard({ onLogout, token, role }) {
@@ -124,6 +126,12 @@ export default function AdminDashboard({ onLogout, token, role }) {
                 <button type="button" onClick={() => setActiveMenu('ticket-list')}>
                   <FiMessageSquare className="icon" />
                   <span>Lista de Tickets</span>
+                </button>
+              </li>
+              <li className={activeMenu === 'ticket-create' ? 'active' : ''}>
+                <button type="button" onClick={() => setActiveMenu('ticket-create')}>
+                  <FiPlusCircle className="icon" />
+                  <span>Crear Tickets</span>
                 </button>
               </li>
               <li className={activeMenu === 'users' ? 'active' : ''}>
@@ -267,6 +275,12 @@ export default function AdminDashboard({ onLogout, token, role }) {
           )}
           {activeMenu === 'ticket-list' && (
             <TicketTable token={token} />
+          )}
+          {activeMenu === 'ticket-create' && (
+            <div>
+              <h3>Crear Tickets</h3>
+              <TicketForm token={token} />
+            </div>
           )}
           {activeMenu === 'users' && (<UserManagement token={token} />)}
           {activeMenu === 'settings' && (

--- a/helpdesk-frontend/src/components/TicketTable.css
+++ b/helpdesk-frontend/src/components/TicketTable.css
@@ -1,0 +1,16 @@
+.ticket-table {
+  width: 100%;
+  border-collapse: collapse;
+  color: var(--dark);
+}
+
+.ticket-table th,
+.ticket-table td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: left;
+}
+
+.ticket-table th {
+  background: #f9f9f9;
+}

--- a/helpdesk-frontend/src/components/TicketTable.jsx
+++ b/helpdesk-frontend/src/components/TicketTable.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import './TicketTable.css';
 
 const API_URL = process.env.REACT_APP_API_URL || 'http://localhost:5131/api';
 
@@ -21,7 +22,7 @@ export default function TicketTable({ token }) {
   return (
     <div>
       <h2>Lista de Tickets</h2>
-      <table border="1" cellPadding="4" cellSpacing="0">
+      <table className="ticket-table">
         <thead>
           <tr>
             <th>ID</th>


### PR DESCRIPTION
## Summary
- add "Crear Tickets" section in admin sidebar and display TicketForm
- darken ticket table text for better readability

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_68b9dedf0d9c8329a6e9a0598fd5dbf0